### PR TITLE
Information about --heap-size-hint and environment variables in .bashrc not propagating to jobs

### DIFF
--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -114,7 +114,7 @@ path or set an environment variable accordingly.
 
 [⤴ _**back to Content**_](#content)
 
-## Julia unexpected killed for exceeding the requested memory limit
+## Julia unexpectedly killed for exceeding the requested memory limit
 
 If a job has non-exclusive access to a node and has a memory limit that is lower than the total memory of the node, set the `--heap-size-hint` command line option to an appropriate value when starting Julia in the job script, e.g. `julia --heap-size-hint=4G my_script.jl` if you have requested a memory limit of 4G for running `my_script.jl`. This communicates the memory limit to Julia's garbage collector to enable more aggressive garbage collection when the memory limit is approached.
 

--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -132,12 +132,6 @@ By default, Julia uses many parallel tasks during precompilation. On the login n
 
 [⤴ _**back to Content**_](#content)
 
-## Julia crashes on startup on a login node
-
-Related to the previous question, if the login node forbids using more than a certain number of threads, it could cause Julia's dependent `C`/`C++` libraries to fail to load. In these cases, you might want to set [`OMP_NUM_THREADS`](https://www.openmp.org/spec-html/5.0/openmpse50.html) to a low value, e.g. `export OMP_NUM_THREADS=1`.
-
-[⤴ _**back to Content**_](#content)
-
 ## Can I precompile GPU code on a login node without a GPU?
 
 Yes, at least for CUDA.jl. See [this part](https://cuda.juliagpu.org/stable/installation/overview/#Precompiling-CUDA.jl-without-CUDA) of the CUDA.jl documentation.

--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -126,6 +126,12 @@ By default, Julia uses many parallel tasks during precompilation. On the login n
 
 [⤴ _**back to Content**_](#content)
 
+## Julia crashes on startup on a login node
+
+Related to the previous question, if the login node forbids using more than a certain number of threads, it could cause Julia's dependent `C`/`C++` libraries to fail to load. In these cases, you might want to set [`OMP_NUM_THREADS`](https://www.openmp.org/spec-html/5.0/openmpse50.html) to a low value, e.g. `export OMP_NUM_THREADS=1`.
+
+[⤴ _**back to Content**_](#content)
+
 ## Can I precompile GPU code on a login node without a GPU?
 
 Yes, at least for CUDA.jl. See [this part](https://cuda.juliagpu.org/stable/installation/overview/#Precompiling-CUDA.jl-without-CUDA) of the CUDA.jl documentation.

--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -116,7 +116,7 @@ path or set an environment variable accordingly.
 
 ## Julia unexpected killed for exceeding the requested memory limit
 
-If a job has non-exclusive access to a node and has a memory limit that is lower than the total memory of the node, set the `--heap-size-hint` command line option to an appropriate value when starting Julia in the job script, e.g. `julia --heap-size-hint=4G my_script.jl` if you have requested a memory limit of 4G for running `my_script.jl`.
+If a job has non-exclusive access to a node and has a memory limit that is lower than the total memory of the node, set the `--heap-size-hint` command line option to an appropriate value when starting Julia in the job script, e.g. `julia --heap-size-hint=4G my_script.jl` if you have requested a memory limit of 4G for running `my_script.jl`. This communicates the memory limit to Julia's garbage collector to enable more aggressive garbage collection when the memory limit is approached.
 
 [⤴ _**back to Content**_](#content)
 

--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -114,6 +114,12 @@ path or set an environment variable accordingly.
 
 [⤴ _**back to Content**_](#content)
 
+## Julia unexpected killed for exceeding the requested memory limit
+
+If a job has non-exclusive access to a node and has a memory limit that is lower than the total memory of the node, set the `--heap-size-hint` command line option to an appropriate value when starting Julia in the job script, e.g. `julia --heap-size-hint=4G my_script.jl` if you have requested a memory limit of 4G for running `my_script.jl`.
+
+[⤴ _**back to Content**_](#content)
+
 ## I get memory-related issues when using CUDA.jl on a HPC cluster
 
 Try setting `JULIA_CUDA_MEMORY_POOL=none` (see the [CUDA.jl documentation](https://cuda.juliagpu.org/stable/usage/memory/#Memory-pool) for more information).

--- a/website/user_gettingstarted.md
+++ b/website/user_gettingstarted.md
@@ -50,7 +50,7 @@ You want to choose a file system with the following properties
 
 On many clusters, the sections above are all you need to get a solid Julia setup. However, if you're on a **heterogeneous HPC cluster**, that is, if different nodes have different CPU (micro-)architectures, you should/need to do a few more preparations. Otherwise, you might encounter nasty error messages like "`Illegal instruction`".
 
-To make Julia produce efficient code that works on different CPUs, you need to set [`JULIA_CPU_TARGET`](https://docs.julialang.org/en/v1.10-dev/manual/environment-variables/#JULIA_CPU_TARGET). For example, if you want Julia to compile all functions (`clone_all`) for Intel Skylake (`skylake-avx512`), AMD Zen 2 (`znver2`), and a generic fallback (`generic`), for safety, you could put the following into your `.bashrc` (also in your job script if the job includes precompilation, which is usually NOT recommended):
+To make Julia produce efficient code that works on different CPUs, you need to set [`JULIA_CPU_TARGET`](https://docs.julialang.org/en/v1.10-dev/manual/environment-variables/#JULIA_CPU_TARGET). For example, if you want Julia to compile all functions (`clone_all`) for Intel Skylake (`skylake-avx512`), AMD Zen 2 (`znver2`), and a generic fallback (`generic`), for safety, you could put the following into your `.bashrc`:
 
 `export JULIA_CPU_TARGET="generic;skylake-avx512,clone_all;znver2,clone_all"`.
 

--- a/website/user_gettingstarted.md
+++ b/website/user_gettingstarted.md
@@ -39,7 +39,7 @@ You want to choose a file system with the following properties
 * good (parallel) I/O
 * no automatic deletion of unused files (or otherwise you have to find a workaround)
 
-**On most clusters these criterion are best fit on a parallel file system (often `$SCRATCH`).** In this case, you should put `JULIA_DEPOT_PATH=$SCRATCH/.julia` into your `.bashrc`.
+**On most clusters these criterion are best fit on a parallel file system (often `$SCRATCH`).** In this case, you should put `JULIA_DEPOT_PATH=$SCRATCH/.julia` into your `.bashrc` (and your job scripts if `.bashrc` is not loaded by non-interactive jobs).
 
 **Note:** If the last point (automatic deletion of unused files) is an issue for you, a pragmatic workaround could be a cronjob that touches all files in the Julia depot every once in a while.
 
@@ -54,6 +54,6 @@ To make Julia produce efficient code that works on different CPUs, you need to s
 
 `export JULIA_CPU_TARGET="generic;skylake-avx512,clone_all;znver2,clone_all"`.
 
-You can get the CPU target name for the current system with `Sys.CPU_NAME`. For more information, see [this section of the Julia documentation](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_CPU_TARGET) and [this section of the developer documentation](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets).
+Also include this line in your job scripts if `.bashrc` is not loaded by non-interactive jobs. You can get the CPU target name for the current system with `Sys.CPU_NAME`. For more information, see [this section of the Julia documentation](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_CPU_TARGET) and [this section of the developer documentation](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets).
 
 [⤴ _**back to Content**_](#content)

--- a/website/user_gettingstarted.md
+++ b/website/user_gettingstarted.md
@@ -50,10 +50,10 @@ You want to choose a file system with the following properties
 
 On many clusters, the sections above are all you need to get a solid Julia setup. However, if you're on a **heterogeneous HPC cluster**, that is, if different nodes have different CPU (micro-)architectures, you should/need to do a few more preparations. Otherwise, you might encounter nasty error messages like "`Illegal instruction`".
 
-To make Julia produce efficient code that works on different CPUs, you need to set [`JULIA_CPU_TARGET`](https://docs.julialang.org/en/v1.10-dev/manual/environment-variables/#JULIA_CPU_TARGET). For example, if you want Julia to compile all functions (`clone_all`) for Intel Skylake (`skylake-avx512`), AMD Zen 2 (`znver2`), and a generic fallback (`generic`), for safety, you could put the following into your `.bashrc`:
+To make Julia produce efficient code that works on different CPUs, you need to set [`JULIA_CPU_TARGET`](https://docs.julialang.org/en/v1.10-dev/manual/environment-variables/#JULIA_CPU_TARGET). For example, if you want Julia to compile all functions (`clone_all`) for Intel Skylake (`skylake-avx512`), AMD Zen 2 (`znver2`), and a generic fallback (`generic`), for safety, you could put the following into your `.bashrc` (also in your job script if the job includes precompilation, which is usually NOT recommended):
 
 `export JULIA_CPU_TARGET="generic;skylake-avx512,clone_all;znver2,clone_all"`.
 
-Also include this line in your job scripts if `.bashrc` is not loaded by non-interactive jobs. You can get the CPU target name for the current system with `Sys.CPU_NAME`. For more information, see [this section of the Julia documentation](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_CPU_TARGET) and [this section of the developer documentation](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets).
+You can get the CPU target name for the current system with `Sys.CPU_NAME`. For more information, see [this section of the Julia documentation](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_CPU_TARGET) and [this section of the developer documentation](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets).
 
 [⤴ _**back to Content**_](#content)


### PR DESCRIPTION
In _FAQ_, I added info about using Julia's command line option `--heap-size-hint` for jobs restricted to use a partial amount of RAM on a node, and info about setting `OMP_NUM_THREADS=1` to prevent C/C++ libraries loaded by Julia from crashing when a login node has a tight resource limit. In _Getting Started_, I added that the various environment variables added to `.bashrc` also need to be added to job scripts if the cluster's job scheduler doesn't propagator `.bashrc` environment variables to non-interactive jobs.