### PR TITLE
Comment on julia installation location with juliaup installer

### DIFF
--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -25,6 +25,12 @@ Yes, absolutely. You **do not** need root privileges to install Julia and its pa
 
 [⤴ _**back to Content**_](#content)
 
+## Julia installed from juliaup not found in a non-interactive job
+
+The installation path of the `julia` executable will be added to your `~/.bashrc` by [juliaup](https://github.com/JuliaLang/juliaup). If the job scheduler does not load `.bashrc` in non-interactive jobs, you can find out the installation path by starting the Julia REPL and type `Sys.BINDIR`.
+
+[⤴ _**back to Content**_](#content)
+
 ## Where should I put the Julia depot?
 
 Ideally, you should set `JULIA_DEPOT_PATH` to point to a place with the following properties:

--- a/website/user_faq.md
+++ b/website/user_faq.md
@@ -27,7 +27,7 @@ Yes, absolutely. You **do not** need root privileges to install Julia and its pa
 
 ## Julia installed from juliaup not found in a non-interactive job
 
-The installation path of the `julia` executable will be added to your `~/.bashrc` by [juliaup](https://github.com/JuliaLang/juliaup). If the job scheduler does not load `.bashrc` in non-interactive jobs, you can find out the installation path by starting the Julia REPL and type `Sys.BINDIR`.
+The installation path of the `julia` executable will be added to your `~/.bashrc` by [juliaup](https://github.com/JuliaLang/juliaup). If the job scheduler does not load `.bashrc` in non-interactive jobs, you must use the full path to `julia` in your job script. You can find out the full path by starting the Julia REPL and typing `Sys.BINDIR`. By default, it should be `~/.juliaup/bin/julia`.
 
 [⤴ _**back to Content**_](#content)
 

--- a/website/user_gettingstarted.md
+++ b/website/user_gettingstarted.md
@@ -23,7 +23,7 @@ Getting started with Julia on a new cluster can sometimes be a challenge. Below 
 
 When starting on a new HPC cluster the first thing you should do is figure out if there is a pre-configured Julia module ([Lmod module](https://lmod.readthedocs.io/en/latest/010_user.html)) available on the cluster. To that end, `module key julia` or `module spider julia` might be helpful commands.
 
-If there is no Julia module available that you can load, you should download and use the regular, precompiled Julia binaries. We strongly recommend to use [juliaup](https://github.com/JuliaLang/juliaup) for this. Alternatively, you can also manually download the binaries directly [from the website](https://julialang.org/downloads/). In any case, you should generally **not** build Julia from source (unless you have a very good reason).
+If there is no Julia module available that you can load, you should download and use the regular, precompiled Julia binaries. We strongly recommend to use [juliaup](https://github.com/JuliaLang/juliaup) for this. The installation path of the `julia` executable will be added to your `~/.bashrc` by `juliaup`. If the job scheduler does not load `.bashrc` in non-interactive jobs, you can find out the installation path by starting the Julia REPL and type `Sys.BINDIR`.  Alternatively, you can also manually download the binaries directly [from the website](https://julialang.org/downloads/). In any case, you should generally **not** build Julia from source (unless you have a very good reason).
 
 Note that you **do not** need root privileges. Julia, and its packages, works great without special permissions in user space.
 

--- a/website/user_gettingstarted.md
+++ b/website/user_gettingstarted.md
@@ -23,7 +23,7 @@ Getting started with Julia on a new cluster can sometimes be a challenge. Below 
 
 When starting on a new HPC cluster the first thing you should do is figure out if there is a pre-configured Julia module ([Lmod module](https://lmod.readthedocs.io/en/latest/010_user.html)) available on the cluster. To that end, `module key julia` or `module spider julia` might be helpful commands.
 
-If there is no Julia module available that you can load, you should download and use the regular, precompiled Julia binaries. We strongly recommend to use [juliaup](https://github.com/JuliaLang/juliaup) for this. The installation path of the `julia` executable will be added to your `~/.bashrc` by `juliaup`. If the job scheduler does not load `.bashrc` in non-interactive jobs, you can find out the installation path by starting the Julia REPL and type `Sys.BINDIR`.  Alternatively, you can also manually download the binaries directly [from the website](https://julialang.org/downloads/). In any case, you should generally **not** build Julia from source (unless you have a very good reason).
+If there is no Julia module available that you can load, you should download and use the regular, precompiled Julia binaries. We strongly recommend to use [juliaup](https://github.com/JuliaLang/juliaup) for this. Alternatively, you can also manually download the binaries directly [from the website](https://julialang.org/downloads/). In any case, you should generally **not** build Julia from source (unless you have a very good reason).
 
 Note that you **do not** need root privileges. Julia, and its packages, works great without special permissions in user space.
 


### PR DESCRIPTION
I use clusters with the Sun Grid Engine (SGE), and a common issue is that environment variables of the interactive shell are not propagated to non-interactive jobs. Therefore, I'm submitting another pull request related to this. The `juliaup` installer adds the `julia` installation path to `~/.bashrc`. For users who cannot depend on `~/.bashrc` being loaded by non-interactive jobs, I've added a tip for finding out the `julia` path by running `Sys.BINDIR` in the Julia REPL.